### PR TITLE
Briceburg/template pathing

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -24,6 +24,7 @@ exports.render = function(template, config, cb) {
             let modulePath = util.format('./views/%s.js', engine);
             let templatePath = path.isAbsolute(template) ? template : process.cwd() + '/' + template;
             fs.accessSync(templatePath, (fs.constants || fs).R_OK);
+            process.chdir(path.dirname(templatePath));
             return require(modulePath)(templatePath, config, cb);
         } catch (e) {
             console.log(e.stack || e.toString());

--- a/lib/template.js
+++ b/lib/template.js
@@ -23,7 +23,7 @@ exports.render = function(template, config, cb) {
         try {
             let modulePath = util.format('./views/%s.js', engine);
             let templatePath = path.isAbsolute(template) ? template : process.cwd() + '/' + template;
-            fs.accessSync(templatePath, fs.constants.R_OK);
+            fs.accessSync(templatePath, (fs.constants || fs).R_OK);
             return require(modulePath)(templatePath, config, cb);
         } catch (e) {
             console.log(e.stack || e.toString());


### PR DESCRIPTION
an alternative is to handle in the template engine view, but this should "just work" for most engines.