### PR TITLE
add EJS template support

### DIFF
--- a/examples/views/Dockerfile.ejs
+++ b/examples/views/Dockerfile.ejs
@@ -1,0 +1,45 @@
+# blueacorn base alpine image
+#  includes /entrypoint.d pattern
+
+FROM <%= defaults.from %>
+
+# Install core packages
+#######################
+
+RUN apk add --update \
+    bash \
+    curl \
+    openssl \
+    openssh-client && \
+    rm -rf /var/cache/apk/*
+
+# for templating
+RUN curl -Lfo /usr/bin/substenv \
+  https://blueacorn:pass4blueacorn@files.badevops.com/util/substenv.musl && \
+  chmod +x /usr/bin/substenv
+
+# rename UID: 33 to www-data to match Debian
+RUN sed -i 's/^xfs:/www-data:/' /etc/passwd && \
+    sed -i 's/^xfs:x:33:xfs/www-data:x:33:www-data/' /etc/group
+
+
+# GLOBAL VARS
+#############
+
+ENV DOCKER_DIR="/docker" \
+    DOCKER_CACHE_DIR="$DOCKER_DIR/cache" \
+    DOCKER_ONRUN_DIR="$DOCKER_DIR/entrypoint.d"
+
+RUN mkdir -p $DOCKER_DIR $DOCKER_CACHE_DIR $DOCKER_ONRUN_DIR
+
+
+# IMAGE RUNTIME
+###############
+
+COPY docker-entrypoint.sh $DOCKER_DIR/entrypoint.sh
+ENTRYPOINT ["/docker/entrypoint.sh"]
+
+# fixperms helper so you don't need to chmod +x files added to DOCKER_ONRUN_DIR
+RUN printf '%s\n' '#!/bin/sh' \
+  'for file in $DOCKER_ONRUN_DIR/*; do chmod +x "$file"; done' > \
+  $DOCKER_ONRUN_DIR/00-fixperms.sh && chmod +x $DOCKER_ONRUN_DIR/00-fixperms.sh

--- a/lib/template.js
+++ b/lib/template.js
@@ -6,6 +6,7 @@ var views = require('./views');
 
 var templateEngines = {
   dust: ['dust'],
+  ejs: ['ejs'],
   handlebars: ['hbs','handlebars'],
   marko: ['marko'],
   nunjucks: ['njk','nunjucks', 'j2', 'jinja', 'jinja2']

--- a/lib/views/ejs.js
+++ b/lib/views/ejs.js
@@ -1,0 +1,12 @@
+var ejs = require('ejs');
+
+// see: https://github.com/mde/ejs
+
+module.exports = function(templatePath, data, cb) {
+    var options = {
+      cache: false,
+      compileDebug: false,
+      rmWhitespace: false
+    }
+    ejs.renderFile(templatePath, data, options, cb);
+}

--- a/lib/views/index.js
+++ b/lib/views/index.js
@@ -4,6 +4,7 @@
 
 module.exports = {
     dust: require('./dust'),
+    ejs: require('./ejs'),
     handlebars: require('./handlebars'),
     marko: require('./marko'),
     nunjucks: require('./nunjucks')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "commander": "*",
     "dustjs-linkedin": "*",
+    "ejs": "*",
     "handlebars": "*",
     "handy": "*",
     "htmlparser": "*",

--- a/test/fixtures/help.txt
+++ b/test/fixtures/help.txt
@@ -25,6 +25,7 @@
  Template Engines:
 
     dust - *.dust
+    ejs - *.ejs
     handlebars - *.hbs, *.handlebars
     marko - *.marko
     nunjucks - *.njk, *.nunjucks, *.j2, *.jinja, *.jinja2

--- a/test/template.js
+++ b/test/template.js
@@ -58,6 +58,24 @@ describe('CLI - Valid Templates', function() {
         });
     });
 
+    describe('EJS Templates', function() {
+        it("Valid template type", function(done) {
+            exec(helpers.appRoot + 'bin/cop --render-template examples/views/Dockerfile.ejs examples/setting.json',
+                function(error, stdout, stderr) {
+                    expect(stdout.trim()).to.equal(helpers.readFixture("Dockerfile01"));
+                    done();
+                });
+        });
+
+        it("Valid template type with multiple inputs", function(done) {
+            exec(helpers.appRoot + 'bin/cop --render-template examples/views/Dockerfile.ejs examples/setting.json examples/setting.yml',
+                function(error, stdout, stderr) {
+                    expect(stdout.trim()).to.equal(helpers.readFixture("Dockerfile02"));
+                    done();
+                });
+        });
+    });
+
     describe('Marko Templates', function() {
        it("render github push payload as html", function(done) {
            exec(helpers.appRoot + 'bin/cop --render-template examples/views/github-push.marko test/fixtures/github-push.json',


### PR DESCRIPTION
@jasmith590 adds EJS template support -- http://ejs.co/

the tests are super simple (e.g. all the templates test for a single string interpolation) and probably should be fleshed out per engine.